### PR TITLE
add enum map generation

### DIFF
--- a/src/head.ts
+++ b/src/head.ts
@@ -1,13 +1,15 @@
 export const head = `
 type field('root, 'base) = 'root => 'base;
 
+type enumMap('enum) = ('enum => string, string => option('enum));
+
 let verifyGraphQLType = (~typename, json) =>
   switch (json->Js.Json.decodeObject) {
   | None =>
     Js.log({j|Unable to decode $typename object|j});
     raise(Not_found);
   | Some(root) =>
-    switch (root->Js.Dict.get("__typename")) {
+    typename == "Query" ? root : switch (root->Js.Dict.get("__typename")) {
     | None =>
       Js.log("Provided object is not a GraphQL object");
       raise(Not_found);

--- a/src/head.ts
+++ b/src/head.ts
@@ -1,7 +1,10 @@
 export const head = `
 type field('root, 'base) = 'root => 'base;
 
-type enumMap('enum) = ('enum => string, string => option('enum));
+type enumMap('enum) = {
+  toString: 'enum => string, 
+  fromString: string => option('enum),
+};
 
 let verifyGraphQLType = (~typename, json) =>
   switch (json->Js.Json.decodeObject) {

--- a/src/root.ts
+++ b/src/root.ts
@@ -27,10 +27,10 @@ const writeCustomScalars = (scalars: { [scalarName: string]: string }) => {
 const writeEnumMap = (type: Enum) => {
   const typeName = makeEnumTypeName(type.name);
   return `
-  let ${camelCase(type.name)}Map: enumMap(${typeName}) = (
-    ${typeName}ToJs,
-    ${typeName}FromJs
-  );
+  let ${camelCase(type.name)}Map: enumMap(${typeName}) = {
+    toString: ${typeName}ToJs,
+    fromString: ${typeName}FromJs
+  };
   `;
 };
 

--- a/src/root.ts
+++ b/src/root.ts
@@ -24,11 +24,23 @@ const writeCustomScalars = (scalars: { [scalarName: string]: string }) => {
   `);
 };
 
+const writeEnumMap = (type: Enum) => {
+  const typeName = makeEnumTypeName(type.name);
+  return `
+  let ${camelCase(type.name)}Map: enumMap(${typeName}) = (
+    ${typeName}ToJs,
+    ${typeName}FromJs
+  );
+  `;
+};
+
 const writeEnumType = (type: Enum) => {
   const values = type.values.map(({ value }) => `| \`${value} `).join("");
   return `
 [@bs.deriving jsConverter]
 type ${makeEnumTypeName(type.name)} = [ ${values}];
+
+${writeEnumMap(type)}
 `;
 };
 

--- a/tester/__tests__/CodegenTest.re
+++ b/tester/__tests__/CodegenTest.re
@@ -254,12 +254,12 @@ describe("parsing JSON", () => {
 
     describe("Enum maps", () => {
       test("can encode a string with the map", () => {
-        let (toString, _) = postStatusMap;
+        let {toString} = postStatusMap;
         Expect.(expect(`PUBLISHED->toString) |> toEqual("PUBLISHED"));
       });
 
       test("can decode a string with the map", () => {
-        let (_, fromString) = postStatusMap;
+        let {fromString} = postStatusMap;
         Expect.(
           expect("PUBLISHED"->fromString) |> toEqual(Some(`PUBLISHED))
         );

--- a/tester/__tests__/CodegenTest.re
+++ b/tester/__tests__/CodegenTest.re
@@ -251,6 +251,20 @@ describe("parsing JSON", () => {
       let posts = data->Js.Json.parseExn->Query.posts;
       Expect.(expect(posts[0]->Post.statuses[0]) |> toEqual(`PUBLISHED));
     });
+
+    describe("Enum maps", () => {
+      test("can encode a string with the map", () => {
+        let (toString, _) = postStatusMap;
+        Expect.(expect(`PUBLISHED->toString) |> toEqual("PUBLISHED"));
+      });
+
+      test("can decode a string with the map", () => {
+        let (_, fromString) = postStatusMap;
+        Expect.(
+          expect("PUBLISHED"->fromString) |> toEqual(Some(`PUBLISHED))
+        );
+      });
+    });
   });
 
   describe("naming collisions", () =>


### PR DESCRIPTION
## The Problem

GraphQL `enum`s get parsed into specific Reason polymorphic variant types using `[@bs.deriving jsConverter]`. That means you already have access to a `[typeName]ToJs` and `[typeName]FromJs` method for serializing/deserializing the type. But, since these method names are generated and based on the type name, it's not possible to use them generically - like if you wanted to have a component/function that took an arbitrary enum and needed to serialize/deserialize it.

## The solution

This PR adds a new base type called `enumMap`:

```reason
type enumMap('enum) = {
  toString: 'enum => string, 
  fromString: string => option('enum),
};
```

Then, for each `Enum` in your GraphQL schema, you'll get a "mapper" object with those two methods on it for serializing/deserializing. You can now write a component/function that deals with `enum`s that takes an `enumMap` type as a prop/argument so that it can work with it internally.

### For example...

Say we're working with an enum that dictates the sort order for a list of things we're querying:

```graphql
enum GiverOrderByInput {
  lastName_ASC
  lastName_DESC
  dateOfLastGift_ASC
  dateOfLastGift_DESC
  totalGifts_ASC
  totalGifts_DESC
  totalGiven_ASC
  totalGiven_DESC
}
```

On the client, we're putting this value in the page's query string when it's set, and thing using it to generate the query variables - so we need to be able to serialize it into a string for writing it to the URL, and then elsewhere parse the string into the enumerated type (handling the case where it's `None`).

With `enumMap`, we can write generic components that:

 1. Handle the user selecting a sort option by passing around the variant constructor, then serializing it to a string and updating the URL's query string.
 2. Watches for changes to the URL's query string, and deserializes the `sort` parameter into a variant constructor so that we can pass it to the query variables. By deserializing, you're forced to handle the case where the string doesn't match a known enum value (the `fromString` method returns `None`).