### PR TITLE
support parsing GQL ints as Reason ints

### DIFF
--- a/src/head.ts
+++ b/src/head.ts
@@ -112,6 +112,8 @@ let makeNullableDecoder =
   };
 };
 
+let decodeInt = json => json->Js.Json.decodeNumber->Belt.Option.map(int_of_float);
+
 let getString: graphQLDecoder('root, string) =
   makeDecoder(~decoder=Js.Json.decodeString);
 
@@ -123,6 +125,12 @@ let getFloat: graphQLDecoder('root, float) =
 
 let getNullableFloat: graphQLDecoder('root, option(float)) =
   makeNullableDecoder(~decoder=Js.Json.decodeNumber);
+
+let getInt: graphQLDecoder('root, int) =
+  makeDecoder(~decoder=decodeInt);
+
+let getNullableInt: graphQLDecoder('root, option(int)) =
+  makeNullableDecoder(~decoder=decodeInt);
 
 let getBool: graphQLDecoder('root, bool) =
   makeDecoder(~decoder=Js.Json.decodeBoolean);

--- a/src/root.ts
+++ b/src/root.ts
@@ -39,7 +39,7 @@ const writeObjectTypeDef = (type: Type) => {
 
 const scalarMap: ScalarMap = {
   String: "string",
-  Int: "float",
+  Int: "int",
   Float: "float",
   Boolean: "bool",
   ID: "string"

--- a/tester/__tests__/CodegenTest.re
+++ b/tester/__tests__/CodegenTest.re
@@ -46,7 +46,7 @@ describe("parsing JSON", () => {
                    {"__typename": "Query", "authors": [{"__typename": "Author", "age": 37}]}
                  |};
         let authors = data->Js.Json.parseExn->Query.authors;
-        Expect.(expect(authors[0]->Author.age) |> toBe(37.));
+        Expect.(expect(authors[0]->Author.age) |> toBe(37));
       });
 
       test("it can parse nullable scalar ints that are non-null", () => {
@@ -55,8 +55,8 @@ describe("parsing JSON", () => {
                    |};
         let authors = data->Js.Json.parseExn->Query.authors;
         Expect.(
-          expect(authors[0]->Author.numPosts->Belt.Option.getWithDefault(0.))
-          |> toBe(12.)
+          expect(authors[0]->Author.numPosts->Belt.Option.getWithDefault(0))
+          |> toBe(12)
         );
       });
 
@@ -66,8 +66,8 @@ describe("parsing JSON", () => {
                      |};
         let authors = data->Js.Json.parseExn->Query.authors;
         Expect.(
-          expect(authors[0]->Author.numPosts->Belt.Option.getWithDefault(0.))
-          |> toBe(0.)
+          expect(authors[0]->Author.numPosts->Belt.Option.getWithDefault(0))
+          |> toBe(0)
         );
       });
     });


### PR DESCRIPTION
Previously we were paring GQL `Int` types as `floats` (simply because this is what the Json decoder does natively). This PR adds the ability to parse Ints correctly.